### PR TITLE
Add per-window tab control feature

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -41,5 +41,20 @@
     },
     "optionsTestCloseButton": {
         "message": "Close"
+    },
+    "optionsPerWindowMode": {
+        "message": "Per-Window Tab Control"
+    },
+    "optionsPerWindowModeLabel": {
+        "message": "Enable window-specific lock mode"
+    },
+    "optionsPerWindowModeHelp": {
+        "message": "When enabled, click the extension icon to lock/unlock individual windows. Locked windows force new tabs to open as new windows."
+    },
+    "actionTitleLocked": {
+        "message": "New Tab, New Window (Window Locked)"
+    },
+    "actionTitleUnlocked": {
+        "message": "New Tab, New Window (Window Unlocked)"
     }
 }

--- a/bg.js
+++ b/bg.js
@@ -5,10 +5,22 @@ const SAME_AS_PARENT = 1;
 const MAXIMIZE = 2;
 
 let extensionEnabled = true;
+let lockedWindows = new Set(); // Track locked window IDs
+let perWindowModeEnabled = false;
 
 getOption(optionNames.extensionEnabled, function(enabled) {
     extensionEnabled = enabled;
     updateIcon(enabled);
+});
+
+// Load per-window mode setting on startup
+getOption(optionNames.perWindowMode, function(enabled) {
+    perWindowModeEnabled = enabled;
+});
+
+// Clean up closed windows
+chrome.windows.onRemoved.addListener(function(windowId) {
+    lockedWindows.delete(windowId);
 });
 
 chrome.tabs.onCreated.addListener(function(tab){
@@ -16,7 +28,17 @@ chrome.tabs.onCreated.addListener(function(tab){
         return;
     }
 
-    if (!extensionEnabled) {
+    let shouldCreateNewWindow = false;
+    
+    if (perWindowModeEnabled) {
+        // Per-window mode: only act on locked windows
+        shouldCreateNewWindow = lockedWindows.has(tab.windowId);
+    } else {
+        // Original global mode
+        shouldCreateNewWindow = extensionEnabled;
+    }
+    
+    if (!shouldCreateNewWindow) {
         return;
     }
 
@@ -67,10 +89,22 @@ chrome.tabs.onCreated.addListener(function(tab){
     });
 });
 
-chrome.action.onClicked.addListener(() => {
-    extensionEnabled = !extensionEnabled;
-    setOption(optionNames.extensionEnabled, extensionEnabled);
-    updateIcon(extensionEnabled);
+chrome.action.onClicked.addListener((tab) => {
+    if (perWindowModeEnabled) {
+        // Toggle lock state for current window
+        const windowId = tab.windowId;
+        if (lockedWindows.has(windowId)) {
+            lockedWindows.delete(windowId);
+        } else {
+            lockedWindows.add(windowId);
+        }
+        updateWindowBadge(windowId);
+    } else {
+        // Original global toggle behavior
+        extensionEnabled = !extensionEnabled;
+        setOption(optionNames.extensionEnabled, extensionEnabled);
+        updateIcon(extensionEnabled);
+    }
 });
 
 function updateIcon(enabled) {
@@ -92,3 +126,56 @@ function updateIcon(enabled) {
         title: title,
     });
 }
+
+function updateWindowBadge(windowId) {
+    const isLocked = lockedWindows.has(windowId);
+    
+    // Get all tabs in the window to update badge for all
+    chrome.tabs.query({windowId: windowId}, function(tabs) {
+        tabs.forEach(tab => {
+            chrome.action.setBadgeText({
+                text: isLocked ? "🔒" : "",
+                tabId: tab.id
+            });
+        });
+    });
+    
+    const titleKey = isLocked ? "actionTitleLocked" : "actionTitleUnlocked";
+    chrome.action.setTitle({
+        title: chrome.i18n.getMessage(titleKey)
+    });
+}
+
+// Update badges when switching windows
+chrome.windows.onFocusChanged.addListener(function(windowId) {
+    if (perWindowModeEnabled && windowId !== chrome.windows.WINDOW_ID_NONE) {
+        updateWindowBadge(windowId);
+    }
+});
+
+// Update badge when new tabs are created
+chrome.tabs.onCreated.addListener(function(tab) {
+    if (perWindowModeEnabled && tab.windowId) {
+        // Set badge for new tab
+        const isLocked = lockedWindows.has(tab.windowId);
+        chrome.action.setBadgeText({
+            text: isLocked ? "🔒" : "",
+            tabId: tab.id
+        });
+    }
+});
+
+// Listen for option changes to update perWindowModeEnabled
+chrome.storage.onChanged.addListener(function(changes, namespace) {
+    if (namespace === 'sync') {
+        if (changes[optionNames.perWindowMode]) {
+            perWindowModeEnabled = changes[optionNames.perWindowMode].newValue;
+            // Clear all badges and locked windows when mode changes
+            if (!perWindowModeEnabled) {
+                lockedWindows.clear();
+                chrome.action.setBadgeText({text: ""});
+                updateIcon(extensionEnabled);
+            }
+        }
+    }
+});

--- a/bg.js
+++ b/bg.js
@@ -31,6 +31,17 @@ chrome.windows.onRemoved.addListener(function(windowId) {
     lockedWindows.delete(windowId);
 });
 
+// Handle new windows being created
+chrome.windows.onCreated.addListener(function(window) {
+    if (perWindowModeEnabled) {
+        // New windows should always start unlocked in per-window mode
+        // Update all tabs in the new window to show disabled icon
+        setTimeout(() => {
+            updateWindowIcon(window.id);
+        }, 100);
+    }
+});
+
 chrome.tabs.onCreated.addListener(function(tab){
     if (tab.index == 0){
         return;
@@ -60,13 +71,23 @@ chrome.tabs.onCreated.addListener(function(tab){
             // if the default window position was used, simply create
             // a new window and done.
             if (newWindowsPosition == CASCADE){
-                chrome.windows.create(createData);
+                chrome.windows.create(createData, function(newWindow) {
+                    // Update icon for new window in per-window mode
+                    if (perWindowModeEnabled && newWindow) {
+                        updateWindowIcon(newWindow.id);
+                    }
+                });
                 return;
             }
             // always maximize new window
             if (newWindowsPosition == MAXIMIZE){
                 createData.state = "maximized";
-                chrome.windows.create(createData);
+                chrome.windows.create(createData, function(newWindow) {
+                    // Update icon for new window in per-window mode
+                    if (perWindowModeEnabled && newWindow) {
+                        updateWindowIcon(newWindow.id);
+                    }
+                });
                 return;
             }
             // new window need to be placed to where the current window is.
@@ -84,14 +105,24 @@ chrome.tabs.onCreated.addListener(function(tab){
                 // just create a new window and done if the current
                 // window is in special state.
                 if (nonPositionalStates[curWindow.state]){
-                    chrome.windows.create(createData);
+                    chrome.windows.create(createData, function(newWindow) {
+                        // Update icon for new window in per-window mode
+                        if (perWindowModeEnabled && newWindow) {
+                            updateWindowIcon(newWindow.id);
+                        }
+                    });
                     return;
                 }
                 // create a new window with position setting.
                 delete createData.state;
                 createData.top = curWindow.top;
                 createData.left = curWindow.left;
-                chrome.windows.create(createData);
+                chrome.windows.create(createData, function(newWindow) {
+                    // Update icon for new window in per-window mode
+                    if (perWindowModeEnabled && newWindow) {
+                        updateWindowIcon(newWindow.id);
+                    }
+                });
             });
         });
     });
@@ -174,8 +205,32 @@ chrome.windows.onFocusChanged.addListener(function(windowId) {
 // Update icon when new tabs are created
 chrome.tabs.onCreated.addListener(function(tab) {
     if (perWindowModeEnabled && tab.windowId) {
-        // Set icon for new tab
-        const isLocked = lockedWindows.has(tab.windowId);
+        // Delay icon update to ensure tab is fully initialized
+        setTimeout(() => {
+            // Set icon for new tab
+            const isLocked = lockedWindows.has(tab.windowId);
+            const iconPath = isLocked ? {
+                "24": "img/icon24.png",
+                "32": "img/icon32.png",
+                "48": "img/icon48.png",
+            } : {
+                "24": "img/icon-disabled24.png",
+                "32": "img/icon-disabled32.png",
+                "48": "img/icon-disabled48.png",
+            };
+            chrome.action.setIcon({
+                path: iconPath,
+                tabId: tab.id
+            });
+        }, 100);
+    }
+});
+
+// Handle tabs being attached to windows (moved between windows)
+chrome.tabs.onAttached.addListener(function(tabId, attachInfo) {
+    if (perWindowModeEnabled) {
+        const windowId = attachInfo.newWindowId;
+        const isLocked = lockedWindows.has(windowId);
         const iconPath = isLocked ? {
             "24": "img/icon24.png",
             "32": "img/icon32.png",
@@ -187,7 +242,7 @@ chrome.tabs.onCreated.addListener(function(tab) {
         };
         chrome.action.setIcon({
             path: iconPath,
-            tabId: tab.id
+            tabId: tabId
         });
     }
 });

--- a/bg.js
+++ b/bg.js
@@ -16,6 +16,14 @@ getOption(optionNames.extensionEnabled, function(enabled) {
 // Load per-window mode setting on startup
 getOption(optionNames.perWindowMode, function(enabled) {
     perWindowModeEnabled = enabled;
+    // If per-window mode is enabled on startup, set all windows to show disabled icon
+    if (perWindowModeEnabled) {
+        chrome.windows.getAll({}, function(windows) {
+            windows.forEach(window => {
+                updateWindowIcon(window.id);
+            });
+        });
+    }
 });
 
 // Clean up closed windows
@@ -98,7 +106,7 @@ chrome.action.onClicked.addListener((tab) => {
         } else {
             lockedWindows.add(windowId);
         }
-        updateWindowBadge(windowId);
+        updateWindowIcon(windowId);
     } else {
         // Original global toggle behavior
         extensionEnabled = !extensionEnabled;
@@ -127,14 +135,24 @@ function updateIcon(enabled) {
     });
 }
 
-function updateWindowBadge(windowId) {
+function updateWindowIcon(windowId) {
     const isLocked = lockedWindows.has(windowId);
     
-    // Get all tabs in the window to update badge for all
+    // Get all tabs in the window to update icon for all
     chrome.tabs.query({windowId: windowId}, function(tabs) {
+        const iconPath = isLocked ? {
+            "24": "img/icon24.png",
+            "32": "img/icon32.png",
+            "48": "img/icon48.png",
+        } : {
+            "24": "img/icon-disabled24.png",
+            "32": "img/icon-disabled32.png",
+            "48": "img/icon-disabled48.png",
+        };
+        
         tabs.forEach(tab => {
-            chrome.action.setBadgeText({
-                text: isLocked ? "🔒" : "",
+            chrome.action.setIcon({
+                path: iconPath,
                 tabId: tab.id
             });
         });
@@ -146,20 +164,29 @@ function updateWindowBadge(windowId) {
     });
 }
 
-// Update badges when switching windows
+// Update icons when switching windows
 chrome.windows.onFocusChanged.addListener(function(windowId) {
     if (perWindowModeEnabled && windowId !== chrome.windows.WINDOW_ID_NONE) {
-        updateWindowBadge(windowId);
+        updateWindowIcon(windowId);
     }
 });
 
-// Update badge when new tabs are created
+// Update icon when new tabs are created
 chrome.tabs.onCreated.addListener(function(tab) {
     if (perWindowModeEnabled && tab.windowId) {
-        // Set badge for new tab
+        // Set icon for new tab
         const isLocked = lockedWindows.has(tab.windowId);
-        chrome.action.setBadgeText({
-            text: isLocked ? "🔒" : "",
+        const iconPath = isLocked ? {
+            "24": "img/icon24.png",
+            "32": "img/icon32.png",
+            "48": "img/icon48.png",
+        } : {
+            "24": "img/icon-disabled24.png",
+            "32": "img/icon-disabled32.png",
+            "48": "img/icon-disabled48.png",
+        };
+        chrome.action.setIcon({
+            path: iconPath,
             tabId: tab.id
         });
     }
@@ -170,11 +197,17 @@ chrome.storage.onChanged.addListener(function(changes, namespace) {
     if (namespace === 'sync') {
         if (changes[optionNames.perWindowMode]) {
             perWindowModeEnabled = changes[optionNames.perWindowMode].newValue;
-            // Clear all badges and locked windows when mode changes
+            // Clear locked windows and reset icons when mode changes
             if (!perWindowModeEnabled) {
                 lockedWindows.clear();
-                chrome.action.setBadgeText({text: ""});
                 updateIcon(extensionEnabled);
+            } else {
+                // When enabling per-window mode, set all windows to unlocked (disabled icon)
+                chrome.windows.getAll({}, function(windows) {
+                    windows.forEach(window => {
+                        updateWindowIcon(window.id);
+                    });
+                });
             }
         }
     }

--- a/lib/option.js
+++ b/lib/option.js
@@ -1,12 +1,14 @@
 export const optionNames = {
     extensionEnabled: "extensionEnabled",
     newWindowsPosition: "newWindowsPosition",
+    perWindowMode: "perWindowMode",
 };
 
 export function getOption(name, callback){
     var defaults = {
         [optionNames.extensionEnabled]: true,
         [optionNames.newWindowsPosition]: 0,
+        [optionNames.perWindowMode]: false,
     };
     var query = {};
     query[name] = defaults[name];
@@ -19,6 +21,7 @@ export function setOption(name, value, callback){
     value = {
         [optionNames.extensionEnabled]: Boolean,
         [optionNames.newWindowsPosition]: Number,
+        [optionNames.perWindowMode]: Boolean,
     }[name](value);
     var data = {};
     data[name] = value;

--- a/options.html
+++ b/options.html
@@ -39,6 +39,16 @@ th {
             </div>
           </td>
         </tr>
+        <tr>
+          <th class="message" message="optionsPerWindowMode"></th>
+          <td>
+            <label>
+              <input type="checkbox" name="perWindowMode" id="perWindowMode">
+              <span class="message" message="optionsPerWindowModeLabel"></span>
+            </label>
+            <div class="message" message="optionsPerWindowModeHelp" style="font-size: 85%; margin-top: 0.5em; color: #666;"></div>
+          </td>
+        </tr>
       </table>
     </form>
   </div>

--- a/options.js
+++ b/options.js
@@ -20,3 +20,13 @@ getOption("newWindowsPosition", function(value){
 $("testBtn").addEventListener("click", function(){
     window.open("options_test.html", "_blank");
 });
+
+// Handle perWindowMode checkbox
+const perWindowCheckbox = document.getElementById('perWindowMode');
+perWindowCheckbox.addEventListener('change', function() {
+    setOption('perWindowMode', this.checked);
+});
+
+getOption('perWindowMode', function(value) {
+    perWindowCheckbox.checked = value;
+});


### PR DESCRIPTION
Add a 'Per-Window Tab Control' feature allowing users to lock individual windows, forcing new tabs in those windows to open as new windows.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b009d01-cfa0-4306-b800-ecbf2c4f11a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8b009d01-cfa0-4306-b800-ecbf2c4f11a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

